### PR TITLE
ACT-945-1 Avoid creating duplicate versions when force saving

### DIFF
--- a/lib/acts_as_versioned.rb
+++ b/lib/acts_as_versioned.rb
@@ -285,7 +285,11 @@ module ActiveRecord #:nodoc:
         def save_version!
           # Allocate a new version number
           self.send("#{self.class.version_column}=", next_version)
-          self.save!
+
+          # The record might have callbacks or other mechanisms that will cause
+          # changes such that a new version would be created upon saving, avoid
+          # that here since we're explicitly creating a new version below
+          self.save_without_revision!
 
           # Save a new version
           rev = self.class.versioned_class.new


### PR DESCRIPTION
If the record has unsaved changes when we call `save!` after bumping the version, that will implicitly create a new version (with the new version number)

Right after that bump, we explicitly create a new version, causing a duplicate version entry.