### PR TITLE
When cloning the model access the attributes in a more direct manner

### DIFF
--- a/lib/acts_as_versioned.rb
+++ b/lib/acts_as_versioned.rb
@@ -360,7 +360,10 @@ module ActiveRecord #:nodoc:
           self.class.versioned_columns.each do |col|
             next unless orig_model.has_attribute?(col.name)
             define_method(new_model, col.name.to_sym)
-            new_model.send("#{col.name.to_sym}=", orig_model.send(col.name))
+
+            # We're using read_attribute_before_type_cast to get the value here
+            # to ensure we get the actual value for enum fields
+            new_model.send("#{col.name.to_sym}=", orig_model.read_attribute_before_type_cast(col.name))
           end
 
           if orig_model.is_a?(self.class.versioned_class)


### PR DESCRIPTION
When cloning a model that has enum fields, we need to use `read_attribute_before_type_cast` to get the actual value rather than the friendly value. e.g. 50 rather than "enum_value" string