### PR TITLE
Only use `read_attribute_before_type_cast` for enum fields

### DIFF
--- a/lib/acts_as_versioned.rb
+++ b/lib/acts_as_versioned.rb
@@ -364,7 +364,7 @@ module ActiveRecord #:nodoc:
             # If the field is an enum, use read_attribute_before_type_cast to
             # get the value that would be in the database, not the friendly 
             # name (i.e. 50 vs "narrow")
-            value = if orig_model.defined_enums.include? col.name
+            value = if orig_model.defined_enums&.include? col.name
               orig_model.read_attribute_before_type_cast(col.name)
             else
               orig_model.send(col.name)


### PR DESCRIPTION
Only use `read_attribute_before_type_cast` for enum fields.

Database array fields were returning structs, for example a `bigint[]` column returns:
```
#<struct ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array::Data encoder=#<PG::TextEncoder::Array:0x000000015621fd20 "integer[]"  elements_type=nil needs quotation>, values=[1020675218]>
``` 
from `read_attribute_before_type_cast` but the values directly (`[1020675218]`) from `orig_model.send(col.name)`